### PR TITLE
Initialize input state and guard navigation

### DIFF
--- a/src/Final.tsx
+++ b/src/Final.tsx
@@ -5,7 +5,7 @@ import { useNavigate } from 'react-router'
 import { PATH_PREFIX } from './constants'
 
 export const Final = () => {
-    const [value, setValue] = useState<string>()
+    const [value, setValue] = useState<string>('')
     const navigate = useNavigate();
 
     const answer = import.meta.env.ANSWER || 'winner-winner-chicken-dinner'

--- a/src/Rebus.tsx
+++ b/src/Rebus.tsx
@@ -8,19 +8,22 @@ import { PATH_PREFIX } from './constants';
 
 export const Rebus = () => {
     const navigate = useNavigate();
-    const [value, setValue] = useState<string>();
+    const [value, setValue] = useState<string>("");
 
     const handleChange = ({ target }: ChangeEvent<HTMLInputElement>) => {
         setValue(target.value);
     };
 
     const handleRedirect = () => {
+        if (!value) {
+            return;
+        }
         if (value === 'react-for-life') {
-            navigate(`/${PATH_PREFIX}/${'react-4-life'}`)
-            return
+            navigate(`/${PATH_PREFIX}/${'react-4-life'}`);
+            return;
         }
         navigate(`/${PATH_PREFIX}/${value}`);
-    }
+    };
 
     const handleEnter = ({ key }: KeyboardEvent<HTMLInputElement>) => {
         if (key === "Enter") {


### PR DESCRIPTION
## Summary
- initialize puzzle inputs with empty strings to avoid uncontrolled component warnings
- prevent navigation to malformed routes when no answer is provided

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895bd025b18832687f478a3be1c3b62